### PR TITLE
Add sample jscs setup.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.jscs.json
+++ b/.jscs.json
@@ -1,0 +1,18 @@
+{
+    "requireCurlyBraces": ["if", "else", "for", "while", "do", "try", "catch"],
+    "requireSpaceAfterKeywords": ["if", "else", "for", "while", "do", "switch", "return", "try", "catch"],
+    "disallowLeftStickedOperators": ["?", "+", "-", "/", "*", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
+    "disallowRightStickedOperators": ["?", "+", "/", "*", ":", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
+    "requireRightStickedOperators": ["!"],
+    "requireLeftStickedOperators": [","],
+    "disallowImplicitTypeConversion": ["string"],
+    "disallowKeywords": ["with"],
+    "disallowMultipleLineBreaks": true,
+    "disallowKeywordsOnNewLine": ["else"],
+    "requireLineFeedAtFileEnd": true,
+    "excludeFiles": ["test/data/*.js"],
+    "validateJSDoc": {
+        "checkParamNames": true,
+        "requireParamTypes": true
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "Graphics-API",
+  "version": "0.0.0",
+  "description": "JavaScript graphics library.",
+  "main": "main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Wikiemol/Graphics-API.git"
+  },
+  "author": "",
+  "license": "BSD-2-Clause",
+  "bugs": {
+    "url": "https://github.com/Wikiemol/Graphics-API/issues"
+  },
+  "homepage": "https://github.com/Wikiemol/Graphics-API",
+  "devDependencies": {
+    "jscs": "~1.2.2"
+  }
+}


### PR DESCRIPTION
You can try this if you want. (You can try it without merging into your repo just by checking out mine.) You'll need Node.js, then run:

```
npm install
```

followed by:

```
node_modules/.bin/jscs *.js
```

Unfortunately it doesn't fix the errors for you! The config file is the one that came with jscs, but you can look at the docs to see which config flags you want to modify: https://github.com/mdevils/node-jscs
